### PR TITLE
[EBC_101-3651] tox使いたいため、pythonをinstall

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ RUN sudo apt-get install -y dnsutils awscli expect
 RUN curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash -
 RUN sudo apt-get install -y nodejs npm
 RUN sudo npm install -g npm@3
+RUN sudo apt-get install -y python3-pip
+RUN pip3 install -U setuptools tox
 ADD https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest /usr/local/bin/ecs-cli
 ADD https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 /usr/local/bin/dep
 RUN sudo chmod 755 /usr/local/bin/ecs-cli /usr/local/bin/dep


### PR DESCRIPTION
# 関連チケット

https://ebica.backlog.jp/view/EBC_101-3651
https://github.com/ebisol/ebica_sp/pull/407