### PR TITLE
EBC_101-4430  openjdk-8-jdkのインストールを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN go get github.com/tcnksm/ghr
 RUN sudo apt-get install -y dnsutils awscli expect redis-tools
 RUN curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash -
 RUN sudo apt-get install -y nodejs npm
+RUN sudo apt-get install -y openjdk-8-jdk
 RUN sudo npm install -g npm@3
 RUN sudo apt-get install -y python3-pip
 RUN pip3 install -U setuptools tox


### PR DESCRIPTION
### Backlog のチケット URL

https://ebica.backlog.jp/view/EBC_101-4430

### 目的

Java-APIのデプロイ時のantビルド時にopenjdk-8-jdkが必要ためimage側でインストールする

### やったこと

- apt-getでopenjdk-8-jdkをインストールするコマンドを追記。
- ローカル環境でdockerをビルド、起動しインストールされていることを確認。