### PR TITLE
[EBC_101-7009] golang 1.12化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/golang:1.10
+FROM circleci/golang:1.12
 
 RUN go get github.com/tcnksm/ghr
 RUN sudo apt-get install -y dnsutils awscli expect redis-tools
@@ -9,5 +9,5 @@ RUN sudo npm install -g npm@3
 RUN sudo apt-get install -y python3-pip
 RUN pip3 install -U setuptools tox
 ADD https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest /usr/local/bin/ecs-cli
-ADD https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 /usr/local/bin/dep
+ADD https://github.com/golang/dep/releases/download/v0.5.1/dep-linux-amd64 /usr/local/bin/dep
 RUN sudo chmod 755 /usr/local/bin/ecs-cli /usr/local/bin/dep


### PR DESCRIPTION
# Backlog

https://ebica.backlog.jp/view/EBC_101-7009

# やったこと

go-APIのgolangのversionを1.12にversion up