### PR TITLE
[EBC_101-8422] `FROM circleci/golang:1.12`はdocker hubでbuild時のみにpullしている様子

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # circleci_image_ghr_awscli
-ciecle ci build image. base image is circleci/golang1.9
+ciecle ci build image. base image is circleci/golang1.12


### PR DESCRIPTION
# Backlog

https://ebica.backlog.jp/view/EBC_101-8422

# やったこと

https://github.com/ebisol/circleci_image_ghr_awscli/blob/master/Dockerfile#L1
```
circleci/golang:1.12
```
は、現在go versionが`1.12.10`だが、
ebisolimages/circleci_image_ghr_awscli
では`1.12.3`のまま。
どうやら、docker hubは、build時にのみ取ってくる様子。
https://hub.docker.com/r/ebisolimages/circleci_image_ghr_awscli/builds

なので、buildをもう一度実施するように、commitを作成。

https://ebica.backlog.jp/view/EBC_101-8422
は、ローカル開発環境(1.12.7、1.13.1 )では再現しないことから、
1.12.3 に対してライブラリが最新化されてしまったことが原因ではないかと推測。

※ただし、dep管理化も別途実施
　https://github.com/ebisol/ebica-api-go/pull/777/files