### PR TITLE
[EBC_101-9316] Golangのversionを1.13にupdate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/golang:1.12
+FROM circleci/golang:1.13
 
 RUN go get github.com/tcnksm/ghr
 RUN sudo apt-get install -y dnsutils awscli expect redis-tools


### PR DESCRIPTION
### Backlog のチケット URL

https://ebica.backlog.jp/view/EBC_101-9316

### 目的

golangのバージョンをv1.13にUpdate

