### PR TITLE
[EBC_101-15076] nodeのバージョンを12に変更する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM circleci/golang:1.13
 
 RUN go get github.com/tcnksm/ghr
 RUN sudo apt-get install -y dnsutils awscli expect redis-tools
-RUN curl -sL https://deb.nodesource.com/setup_9.x | sudo -E bash -
+RUN curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
 RUN sudo apt-get install -y nodejs npm
 RUN sudo apt-get install -y openjdk-11-jdk
 RUN sudo npm install -g npm@3


### PR DESCRIPTION
### Backlog のチケット URL
https://ebica.backlog.jp/view/EBC_101-15076

### 目的
ebica-google-apiのテストが異常終了。
　https://app.circleci.com/pipelines/github/ebisol/ebica-google-api/359/workflows/168517f3-3424-4801-9c02-539c0f986abd/jobs/772

nodeのバージョンが古いことが原因かと思われるので、テスト実行時の nodeのバージョンを 12にUpdateする
nodeののバージョンを12にUpdateする
　参考：https://github.com/nodesource/distributions/blob/master/README.md


### 保留事項
ebica-google-apiの nodeバージョンを updateする必要もあるため、（すでにwarning出てる）
その際に、nodeのバージョンを揃えて更新する。
